### PR TITLE
Fix overflow on results

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -85,6 +85,7 @@ button {
   border-radius: 4px;
   width: 100%;
   overflow: hidden; /* Use overflow: hidden as a robust container */
+  overflow-wrap: anywhere; /* Break long words to avoid page overflow */
 }
 
 /* New class to handle long summary lines */
@@ -129,6 +130,10 @@ button {
 #history {
   margin-top: 10px;
   border-top: 1px solid #ccc;
+}
+
+#results {
+  overflow-wrap: anywhere; /* Ensure long content doesn't force horizontal scrolling */
 }
 
 .history-item {


### PR DESCRIPTION
## Summary
- prevent horizontal scroll by wrapping overflow text in result content
- enforce text wrapping inside the results container

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68426938e7cc83328c944f572ed49cac