### PR TITLE
Add new tab interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ This folder holds a lightweight Chrome extension that queries multiple language 
    `https://api.github.com/*` for this purpose.
 
 ## Project Files
-- `manifest.json` – Declares extension permissions and points to `popup.html`.
-- `popup.html` – The popup's HTML structure.
-- `popup.css` – Styles for the popup window.
+- `manifest.json` – Declares extension permissions and registers the background script.
+- `index.html` – Full-page interface opened in a new tab.
+- `popup.html` – (legacy) the original popup HTML.
+- `popup.css` – Shared styles for both the popup and page.
 - `popup.js` – Fetches answers from each provider and maintains conversation history.
 - `markdownWorker.js` – Web worker that sanitizes and renders Markdown.
 - `secrets.js` – **Untracked file** where you place your API keys.
@@ -33,8 +34,8 @@ This folder holds a lightweight Chrome extension that queries multiple language 
 - `pricing.json` – Token price data used to estimate request cost.
 
 ## Usage
-Open the extension popup, enter a question and press **Ask**. Responses from OpenAI, Grok and Gemini will appear in separate columns. A summary line shows which model responded, token counts and the estimated cost. Follow-up prompts keep a conversation going by resending the previous messages. A **Cancel** button appears while answers are loading so you can stop the requests if needed.
-The popup also shows the title and timestamp of the most recent pull request to this repository so you can confirm you're running the latest code.
+Click the extension icon and a new tab opens with the LLM Aggregator page. Enter a question and press **Ask** to query OpenAI, Grok and Gemini side by side. A summary line shows which model responded, token counts and the estimated cost. Follow-up prompts keep a conversation going by resending the previous messages. A **Cancel** button appears while answers are loading so you can stop the requests if needed.
+The page also shows the title and timestamp of the most recent pull request to this repository so you can confirm you're running the latest code.
 
 ## Available Models
 

--- a/background.js
+++ b/background.js
@@ -1,0 +1,3 @@
+chrome.action.onClicked.addListener(() => {
+  chrome.tabs.create({ url: chrome.runtime.getURL('index.html') });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="popup.css">
+  <title>LLM Aggregator</title>
+</head>
+<body>
+  <h1>LLM Aggregator</h1>
+  <div id="last-pr-date"></div>
+  <div id="provider-toggles">
+    <label><input type="checkbox" id="toggle-openai" checked> OpenAI</label>
+    <label><input type="checkbox" id="toggle-grok" checked> Grok</label>
+    <label><input type="checkbox" id="toggle-gemini" checked> Gemini</label>
+  </div>
+  <form id="question-form">
+    <textarea id="question" placeholder="Ask a question (Enter to submit, Shift+Enter for new line)"></textarea>
+    <button id="ask" type="submit">Ask</button>
+  </form>
+  <button id="new-chat">New Chat</button>
+  <button id="toggle-history">Show History</button>
+  <button id="clear-history">Clear History</button>
+  <div id="history" style="display: none;"></div>
+  <div id="loading" style="display: none;">
+    <div id="spinner"></div>
+    <span id="loading-text">Loading...</span>
+    <button id="cancel-loading" style="display:none;">Cancel</button>
+  </div>
+  <div id="results"></div>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,10 @@
   "description": "Query multiple LLM providers and view the results side by side.",
   "version": "1.0.0",
   "action": {
-    "default_title": "LLM Aggregator",
-    "default_popup": "popup.html"
+    "default_title": "LLM Aggregator"
+  },
+  "background": {
+    "service_worker": "background.js"
   },
   "permissions": ["storage"],
   "host_permissions": [


### PR DESCRIPTION
## Summary
- create `index.html` as a full-page interface
- add `background.js` that opens this page when the extension icon is clicked
- update manifest to register the service worker and remove the popup
- document the new behaviour in the README

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8')); console.log('manifest ok');"`

------
https://chatgpt.com/codex/tasks/task_e_68433d3d5ae0833283d01c775d2e8f52