### PR TITLE
Fix hashing fallback for insecure contexts

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,10 +97,18 @@ function saveToggles() {
 async function hashMessages(provider, messages) {
   const str = provider + JSON.stringify(messages);
   const buffer = new TextEncoder().encode(str);
-  const digest = await crypto.subtle.digest('SHA-256', buffer);
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
+  if (crypto.subtle && crypto.subtle.digest) {
+    const digest = await crypto.subtle.digest('SHA-256', buffer);
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  // Fallback for insecure contexts where SubtleCrypto is unavailable
+  let hash = 0;
+  for (const byte of buffer) {
+    hash = (hash * 31 + byte) >>> 0;
+  }
+  return hash.toString(16);
 }
 
 async function getCachedResponse(provider, messages) {

--- a/script.js
+++ b/script.js
@@ -108,10 +108,18 @@ function saveToggles() {
 async function hashMessages(provider, messages) {
   const str = provider + JSON.stringify(messages);
   const buffer = new TextEncoder().encode(str);
-  const digest = await crypto.subtle.digest('SHA-256', buffer);
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
+  if (crypto.subtle && crypto.subtle.digest) {
+    const digest = await crypto.subtle.digest('SHA-256', buffer);
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  // Fallback for insecure contexts where SubtleCrypto is unavailable
+  let hash = 0;
+  for (const byte of buffer) {
+    hash = (hash * 31 + byte) >>> 0;
+  }
+  return hash.toString(16);
 }
 
 async function getCachedResponse(provider, messages) {


### PR DESCRIPTION
## Summary
- avoid crash when `crypto.subtle` is unavailable

## Testing
- `node --check app.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6843c5e31b0c833299db1ba9fef3d9b5